### PR TITLE
various fixes and upgrades

### DIFF
--- a/projects/table-builder/src/lib/components/generic-table/generic-table.component.html
+++ b/projects/table-builder/src/lib/components/generic-table/generic-table.component.html
@@ -45,7 +45,7 @@
 
   </ng-container>
 
-  <mat-header-row *matHeaderRowDef="keys$ | async"></mat-header-row>
+  <mat-header-row *matHeaderRowDef="keys$ | async; sticky: isSticky"></mat-header-row>
   <mat-row *matRowDef="let row; columns: keys$ | async; let i = index"></mat-row>
   <mat-footer-row *matFooterRowDef="keys$ | async"></mat-footer-row>
 

--- a/projects/table-builder/src/lib/components/generic-table/generic-table.component.ts
+++ b/projects/table-builder/src/lib/components/generic-table/generic-table.component.ts
@@ -37,6 +37,7 @@ export class GenericTableComponent implements AfterContentInit, OnInit {
   @Input() columns$: Observable<string[]>;
   @Input() rows: QueryList<MatRowDef<any>>;
   @Input() columnTemplates$: Observable<ColumnTemplates[]>;
+  @Input() isSticky: boolean;
 
   @Output() selection$: Observable<any>;
 

--- a/projects/table-builder/src/lib/components/table-container/table-container.html
+++ b/projects/table-builder/src/lib/components/table-container/table-container.html
@@ -1,6 +1,6 @@
 
   <div class="row">
-    <tb-filter-displayer class="filter-row col-md-11" [filterCols$]="tableBuilder.metaData$" (filters$)="filters$.emit($event)">
+    <tb-filter-displayer class="filter-row col-md-11" [filterCols$]="filterCols$" (filters$)="filters$.emit($event)">
     </tb-filter-displayer>
 
     <tb-col-displayer class="menu pull-right" [cols]="columnNames$" (update)="columnsSelected$.next($event)">
@@ -16,6 +16,7 @@
     [columnTemplates$]='columnTemplates$'
     [columns$]='displayedColumns$'
     [trackBy]='trackBy'
+    [isSticky]='isSticky'
     >
   </tb-generic-table>
 

--- a/projects/table-builder/src/lib/components/table-container/table-container.ts
+++ b/projects/table-builder/src/lib/components/table-container/table-container.ts
@@ -10,8 +10,8 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { Observable, Subject, concat } from 'rxjs';
-import { FieldType } from '../../interfaces/report-def';
-import { first } from 'rxjs/operators';
+import { FieldType, MetaData } from '../../interfaces/report-def';
+import { first, map } from 'rxjs/operators';
 import { FilterInfo } from '../../classes/filter-info';
 import { DataFilter } from '../../classes/data-filter';
 import { mapArray } from '../../functions/rxjs-operators';
@@ -32,6 +32,7 @@ import { CustomCellDirective } from '../../directives/custom-cell-directive';
   @Input() IndexColumn = false;
   @Input() SelectionColumn = false;
   @Input() trackBy: string;
+  @Input() isSticky: boolean = true;
   @Output() filters$ = new EventEmitter();
   @Output() selection$ = new EventEmitter();
   @ViewChild('header', { static: true }) header: TemplateRef<any>;
@@ -47,6 +48,7 @@ import { CustomCellDirective } from '../../directives/custom-cell-directive';
   columnNames$: Observable<string[]>;
   filteredData: DataFilter;
   columnTemplates$: Observable<ColumnTemplates[]>;
+  filterCols$: Observable<MetaData[]>;
 
   ngAfterContentInit() {
     this.InitializeData();
@@ -59,6 +61,10 @@ import { CustomCellDirective } from '../../directives/custom-cell-directive';
         mapArray((fltr: FilterInfo) => fltr.getFunc())
       ),
       this.tableBuilder.getData$()
+    );
+
+    this.filterCols$ = this.tableBuilder.metaData$.pipe(
+      map(md => md.filter(m => m.fieldType !== FieldType.Hidden))
     );
   }
 

--- a/projects/table-builder/src/lib/directives/custom-cell-directive.ts
+++ b/projects/table-builder/src/lib/directives/custom-cell-directive.ts
@@ -1,4 +1,4 @@
-import { Directive, TemplateRef, Input, OnInit, Optional } from '@angular/core';
+import { Directive, TemplateRef, Input, AfterContentInit, Optional } from '@angular/core';
 import { CdkColumnDef } from '@angular/cdk/table';
 
 // here is how to use it
@@ -9,17 +9,17 @@ import { CdkColumnDef } from '@angular/cdk/table';
 @Directive({
     selector: '[customCell]'
 })
-export class CustomCellDirective implements OnInit {
+export class CustomCellDirective implements AfterContentInit {
     @Input() customCell: string;
     @Input() TemplateRef: TemplateRef<any>;
     @Input() customCellOrder: number;
     constructor(
       @Optional()  private templateRef: TemplateRef<any>,
-      @Optional() private columnDef: CdkColumnDef
+      @Optional() public columnDef: CdkColumnDef
       ) {
       this.TemplateRef = this.templateRef;
      }
-    ngOnInit() {
+     ngAfterContentInit() {
       if (this.columnDef) {
         this.TemplateRef = this.columnDef.cell.template;
       } else if (this.TemplateRef === null) {


### PR DESCRIPTION
1) Allow a custom column to override an existing meta-data-generated column while maintaining the meta-data-defined column order.

2) Display custom column header and footer templates; changed the custom cell directive's `CdkColumnDef` from private to public to allow access to the templates outside of the directive

3) Add sticky headers by default, with the option to keep the headers non-sticky 

4) Remove column filter when its meta-data declares the field type as `FieldType.Hidden`

5) After upgrading to Angular v8, changed the hook in the custom cell directive from `OnInit` to `AfterContentInit`.  This is because angular's `CdkColumnDef`, which we are injecting in the directive's constructor, uses a non-static `ContentChild` query to populate its `CdkCellDef` property, and is therefore only available in the `AfterContentInit` hook; the `cell` prop will remain `undefined` in the `OnInit` hook.