### PR TITLE
use display name when custom column overrides meta data column

### DIFF
--- a/projects/table-builder/src/lib/classes/TableTemplateBuilder.ts
+++ b/projects/table-builder/src/lib/classes/TableTemplateBuilder.ts
@@ -40,6 +40,7 @@ export class TableTemplateBuilder {
           const cc = this.customCells.find(cc => cc.customCell === md.key);
           if (cc) {
             cc.customCellOrder = cc.customCellOrder || md.order;
+            cc.displayName = cc.displayName || md.displayName;
           }
         })),
         filterArray(metaData => !this.customCells.map(cc => cc.customCell.toLowerCase()).includes(metaData.key.toLowerCase())),
@@ -74,6 +75,7 @@ export class TableTemplateBuilder {
         body: cc.TemplateRef,
         metaData: {
           key: cc.customCell,
+          displayName: cc.displayName,
           fieldType: FieldType.Unknown,
           order: cc.customCellOrder
         }

--- a/projects/table-builder/src/lib/directives/custom-cell-directive.ts
+++ b/projects/table-builder/src/lib/directives/custom-cell-directive.ts
@@ -11,6 +11,7 @@ import { CdkColumnDef } from '@angular/cdk/table';
 })
 export class CustomCellDirective implements AfterContentInit {
     @Input() customCell: string;
+    @Input() displayName: string;
     @Input() TemplateRef: TemplateRef<any>;
     @Input() customCellOrder: number;
     constructor(


### PR DESCRIPTION
Added a displayName Input to the custom cell directive, and when overriding a meta-data column, I set the displayName equal to the meta-data displayName prop if not already assigned in the directive