### PR TITLE
added FieldType.Array to filter template

### DIFF
--- a/projects/table-builder/src/lib/components/filter/filter.component.html
+++ b/projects/table-builder/src/lib/components/filter/filter.component.html
@@ -18,6 +18,9 @@
             <div class="switch" *ngSwitchCase="FieldType.String" >
                 <ng-container class="switch" *ngTemplateOutlet="String"></ng-container>
             </div>
+            <div class="switch" *ngSwitchCase="FieldType.Array" >
+                <ng-container class="switch" *ngTemplateOutlet="String"></ng-container>
+            </div>
             <div class="switch" *ngSwitchCase="FieldType.Unknown" >
                 <ng-container class="switch" *ngTemplateOutlet="String"></ng-container>
             </div>


### PR DESCRIPTION
Currently, selecting a filter type, i.e "Contains", etc., does not open the next mat-card to input the value because FieldType.Array was not included in the ngSwitch