### PR TITLE
keep filter menu open while clicking

### DIFF
--- a/projects/table-builder/src/lib/components/gen-col-displayer/gen-col-displayer.component.css
+++ b/projects/table-builder/src/lib/components/gen-col-displayer/gen-col-displayer.component.css
@@ -8,7 +8,6 @@
     overflow: hidden;
     white-space: nowrap;
     text-align: left;
-    padding: 18px 0 0 0;
     margin: 0;
     font-size: 17px;
     font-weight: 700;

--- a/projects/table-builder/src/lib/components/gen-col-displayer/gen-col-displayer.component.html
+++ b/projects/table-builder/src/lib/components/gen-col-displayer/gen-col-displayer.component.html
@@ -7,44 +7,44 @@
     <mat-menu #menu="matMenu" class="my-mat-menu">
 
         <button mat-menu-item>
-            <span class="pull-right" matTooltip="Close">
+          <div style="display: flex; flex-direction: row-reverse;">
+            <span matTooltip="Close">
                 <button class="filter-button" mat-icon-button>
                     <mat-icon>close</mat-icon>
                 </button>
             </span>
+          </div>
         </button>
-        <!-- stopClickPropagate() is to avoid the default behavior of the mat-menu from closing after the first click
-        this way the user can close it when their ready -->
-        <button mat-menu-item (click)="stopClickPropagate($event)">
-
-            <span class="pull-left" matTooltip="Show all columns" (click)="reset(displayCols)">
-                <button mat-icon-button>
+        <button mat-menu-item stop-propagation>
+          <div style="display: flex; justify-content: space-between;">
+            <span matTooltip="Show all columns">
+                <button mat-icon-button (click)="reset(displayCols)">
                     <mat-icon color="primary">done_all</mat-icon>
                 </button>
             </span>
 
-            <span matTooltip="Hide all columns" class="pull-right" (click)="unset(displayCols)">
-                <button mat-icon-button>
+            <span matTooltip="Hide all columns">
+                <button mat-icon-button (click)="unset(displayCols)">
                     <mat-icon color="primary">cancel</mat-icon>
                 </button>
             </span>
-
+          </div>
         </button>
 
-        <button [class.isHidden]="!col.isVisible" (click)="stopClickPropagate($event)" mat-menu-item
+        <button [class.isHidden]="!col.isVisible" stop-propagation mat-menu-item
             *ngFor="let col of displayCols">
-            <div (click)="col.isVisible = !col.isVisible; emit(displayCols)">
-                <p class="label">
+            <div (click)="col.isVisible = !col.isVisible; emit(displayCols)" stop-propagation style="display: flex; justify-content: space-between;">
+                <p class="label" style="display: flex;">
                     {{col.displayName || (col.key | spaceCase) }}
                 </p>
-                <span matTooltip="Hide Column" class="show-hide pull-right" *ngIf="col.isVisible; else hidden">
+                <span matTooltip="Hide Column" class="show-hide" *ngIf="col.isVisible; else hidden">
                     <button mat-icon-button>
                         <mat-icon color="primary">check_box</mat-icon>
                     </button>
                 </span>
 
                 <ng-template #hidden >
-                    <span matTooltip="Show Column" class="show-hide pull-right">
+                    <span matTooltip="Show Column" class="show-hide">
                         <button mat-icon-button>
                             <mat-icon>indeterminate_check_box</mat-icon>
                         </button>

--- a/projects/table-builder/src/lib/directives/stop-propagation.directive.ts
+++ b/projects/table-builder/src/lib/directives/stop-propagation.directive.ts
@@ -1,0 +1,19 @@
+import {Directive, HostListener} from "@angular/core";
+
+@Directive({
+    selector: "[stop-propagation]"
+})
+export class StopPropagationDirective
+{
+    @HostListener("click", ["$event"])
+    public onClick(event: any): void
+    {
+        event.stopPropagation();
+    }
+
+    @HostListener("mousedown", ["$event"])
+    public onMousedown(event: any): void
+    {
+        event.stopPropagation();
+    }
+}

--- a/projects/table-builder/src/lib/table-builder.module.ts
+++ b/projects/table-builder/src/lib/table-builder.module.ts
@@ -25,6 +25,7 @@ import { SaveTableEffects } from './ngrx/effects';
 import { KeyDisplayPipe } from './pipes/key-display';
 import { FormatValuePipe } from './pipes/format-value';
 import { RouterModule } from '@angular/router';
+import { StopPropagationDirective } from './directives/stop-propagation.directive';
 
 @NgModule({
   imports: [
@@ -42,7 +43,8 @@ import { RouterModule } from '@angular/router';
         GenColDisplayerComponent,
         GenFilterDisplayerComponent,
         FilterComponent,
-        MultiSortDirective
+        MultiSortDirective,
+        StopPropagationDirective,
     ],
     declarations: [
         SpaceCasePipe,
@@ -60,6 +62,7 @@ import { RouterModule } from '@angular/router';
         HeaderMenuComponent,
         KeyDisplayPipe,
         FormatValuePipe,
+        StopPropagationDirective,
     ],
     providers : [SpaceCasePipe, DatePipe]
 })


### PR DESCRIPTION
I also removed the bootstrap classes (which were not working since you don't include that library) and replaced with flex.  

I added a stop-propagate directive for reuse