### PR TITLE
tweaked

### DIFF
--- a/projects/table-builder/src/lib/pipes/key-display.ts
+++ b/projects/table-builder/src/lib/pipes/key-display.ts
@@ -1,16 +1,16 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { TableStore } from '../classes/table-store';
-import { SpaceCasePipe } from './space-case.pipes';
+import { spaceCase, SpaceCasePipe } from './space-case.pipes';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Pipe({name: 'keyDisplay'})
 export class KeyDisplayPipe implements PipeTransform {
-  constructor( public tableState: TableStore, private spaceCase: SpaceCasePipe) {
+  constructor( public tableState: TableStore) {
   }
   transform(key: string): Observable<string> {
     return this.tableState.getMetaData$(key).pipe(
-      map( metaData => metaData.displayName || this.spaceCase.transform(key))
+      map( metaData => metaData.displayName || spaceCase(key))
     );
   }
 }

--- a/projects/table-builder/src/lib/pipes/key-display.ts
+++ b/projects/table-builder/src/lib/pipes/key-display.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { TableStore } from '../classes/table-store';
-import { spaceCase, SpaceCasePipe } from './space-case.pipes';
+import { spaceCase } from './space-case.pipes';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/projects/table-builder/src/lib/pipes/space-case.pipes.ts
+++ b/projects/table-builder/src/lib/pipes/space-case.pipes.ts
@@ -3,8 +3,21 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({name: 'spaceCase'})
 export class SpaceCasePipe implements PipeTransform {
   transform(value: string): string {
-    return  value?.replace(/([A-Z])/g, ' $1')
+    return  spaceCase(value);
+  }
+}
+
+/**
+ * Adds a space before uppercase letters that either
+ * 1. follows a lowercase letter or digit
+ * 2. or precedes a lowercase letter and follows an alpha-numeric character
+ * 
+ * Uppercases the first digit
+ * 
+ * Turns underscores into spaces
+ */
+export function spaceCase(value: string){
+  return  value?.replace(/(?<=[a-z0-9])([A-Z])|(?<=[a-zA-Z0-9])([A-Z])(?=[a-z])|_/g, ' $1$2')
     // uppercase the first character
     .replace(/^./,  str => str.toUpperCase() );
-  }
 }


### PR DESCRIPTION
Adds a space before uppercase letters that either

follows a lowercase letter or digit
or precedes a lowercase letter and follows an alpha-numeric character
Turns underscores into spaces
Uppercases first letter

Old behavior would turn IRADoc into I R A Doc. New behavior will turn it into IRA Doc

To test paste this into a js repl (like dev tools)

function spaceCase(value){
  return value && value.replace(/(?<=[a-z0-9])([A-Z])|(?<=[a-zA-Z0-9])([A-Z])(?=[a-z])|_/g, ' $1$2')
  // uppercase the first character
  .replace(/^./, function(str) {
       return str.toUpperCase();
  });
}